### PR TITLE
Update rustler and address unused code

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Html5ever.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:rustler, "~> 0.17.0"},
+    [{:rustler, "~> 0.18.0"},
      {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], [], "hexpm"},
+%{
+  "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "rustler": {:hex, :rustler, "0.17.0", "919c03b77abcf4f6ded2a3433b08829b0ec57b9f382af0ae24e4d1e229a7069e", [:mix], [], "hexpm"}}
+  "rustler": {:hex, :rustler, "0.18.0", "db4bd0c613d83a1badc31be90ddada6f9821de29e4afd15c53a5da61882e4f2d", [:mix], [], "hexpm"},
+}

--- a/native/html5ever_nif/Cargo.toml
+++ b/native/html5ever_nif/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = "^0.17"
-rustler_codegen = "^0.17"
+rustler = "^0.18"
+rustler_codegen = "^0.18"
 #rustler = { path = "../../../Rustler/" }
 #rustler_codegen = { path = "../../../Rustler/rustler_codegen/" }
 

--- a/native/html5ever_nif/src/flat_dom.rs
+++ b/native/html5ever_nif/src/flat_dom.rs
@@ -1,6 +1,3 @@
-use ::html5ever;
-use ::markup5ever;
-
 use html5ever::{ QualName, Attribute };
 use html5ever::tree_builder::{ TreeSink, QuirksMode, NodeOrText, ElementFlags };
 use markup5ever::ExpandedName;
@@ -115,11 +112,11 @@ impl TreeSink for FlatSink {
     }
 
     // TODO: Log this or something
-    fn parse_error(&mut self, msg: Cow<'static, str>) {}
-    fn set_quirks_mode(&mut self, mode: QuirksMode) {}
+    fn parse_error(&mut self, _msg: Cow<'static, str>) {}
+    fn set_quirks_mode(&mut self, _mode: QuirksMode) {}
 
     fn get_document(&mut self) -> Self::Handle { NodeHandle(0) }
-    fn get_template_contents(&mut self, target: &Self::Handle) -> Self::Handle {
+    fn get_template_contents(&mut self, _target: &Self::Handle) -> Self::Handle {
         panic!("Templates not supported");
     }
 

--- a/native/html5ever_nif/src/rc_dom.rs
+++ b/native/html5ever_nif/src/rc_dom.rs
@@ -1,7 +1,5 @@
 use ::rustler::{Env, Term, Encoder};
 use ::html5ever::rcdom::{Handle, NodeData};
-use ::html5ever::QualName;
-use ::tendril::StrTendril;
 
 use ::common::{ QNW, STW };
 


### PR DESCRIPTION
This PR 

- [x] Updates rustler and associated libraries to 0.18
- [x] Remove unused functions
- [x] Annotate unused parameters that are present to meet Trait requirements
- [x] Apply rustfmt to the code
- [x] Remove unused import
- [x] Remove unused macro atoms